### PR TITLE
Fix empty project pull + add basic logging

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -475,7 +475,7 @@ def pull_project_finalize(job):
     conflicts = job.mp.apply_pull_changes(job.pull_changes, job.temp_dir)
     job.mp.metadata = {
         'name': job.project_path,
-        'version': job.version,
+        'version': job.version if job.version else "v0",  # for new projects server version is ""
         'files': job.project_info['files']
     }
     

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -1,5 +1,6 @@
 
 import json
+import logging
 import math
 import os
 import re
@@ -47,6 +48,16 @@ class MerginProject:
         self.meta_dir = os.path.join(self.dir, '.mergin')
         if not os.path.exists(self.meta_dir):
             os.mkdir(self.meta_dir)
+
+        # setup logging into project directory's .mergin/client-log.txt file
+        self.log = logging.getLogger('mergin.' + directory)
+        self.log.setLevel(logging.DEBUG)   # log everything (it would otherwise log just warnings+errors)
+        if not self.log.handlers:
+            # we only need to set the handler once
+            # (otherwise we would get things logged multiple times as loggers are cached)
+            log_handler = logging.FileHandler(os.path.join(self.meta_dir, "client-log.txt"))
+            log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+            self.log.addHandler(log_handler)
 
     def fpath(self, file, other_dir=None):
         """

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -166,7 +166,7 @@ def test_push_pull_changes(mc):
     f_conflict_checksum = generate_checksum(os.path.join(project_dir_2, f_updated))
 
     # not at latest server version
-    with pytest.raises(ClientError, match='Update your local repository'):
+    with pytest.raises(ClientError, match='Please update your local copy'):
         mc.push_project(project_dir_2)
 
     # check changes in project_dir_2 before applied


### PR DESCRIPTION
1. Fix a problem when a pull of an empty project would break it
 
    Initial download would save "v0" as the version, then pull was changing it to "" and afterwards push was crashing because it was expecting "v0"

2. Basic logging of sync process to .mergin/client-log.txt