### PR TITLE
Random fixes to CLI and packaging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Mergin python client
+# Mergin Python Client
 
-Repo for [mergin](https://public.cloudmergin.com/) client and basic utils.
+This repository contains a Python client module for access to [Mergin](https://public.cloudmergin.com/)
+service and a command-line tool for easy access to data stored in Mergin.
 
 ## Development
 Python 3.6+ required. Create `mergin/deps` folder where [geodiff](https://github.com/lutraconsulting/geodiff) lib is supposed to be and install dependencies:
@@ -28,13 +29,56 @@ For running test do:
     pipenv run pytest --cov-report html --cov=mergin test/
 
 
-## CLI
-There is command line tool based on [click](https://click.palletsprojects.com/) included, to run it make sure you have click installed:
+## Command-line Tool
 
-    pip install click
+When the module is installed, it comes with `mergin` command line tool.
 
-You can use CLI like this:
+```
+$ mergin --help
+Usage: mergin [OPTIONS] COMMAND [ARGS]...
 
-    chmod +x cli.py
-    sudo ln -s `pwd`/cli.py /usr/bin/mergin
-    mergin login <url>
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  create         Create a new project on Mergin server
+  download       Download last version of mergin project
+  list-projects  List projects on the server
+  login          Fetch new authentication token.
+  modtime        Show files modification time info.
+  pull           Fetch changes from Mergin repository
+  push           Upload local changes into Mergin repository
+  remove         Remove project from server and locally (if exists).
+  status         Show all changes in project files - upstream and local
+```
+
+To start using `mergin`, first run its "login" command to get authorization token:
+
+```
+$ mergin login
+```
+
+It will ask for username and password and then output environment variables
+with authorization. The returned token is not permanent - it will expire after
+several hours. When the variables are set, it is possible to run other commands,
+for example, to download a project:
+
+```
+$ mergin download username/project1 ~/mergin/project1
+```
+
+When a project is downloaded, `mergin` commands can be run in the project's
+working directory:
+
+1. get status of the project (check if there are any local/remote changes)
+   ```
+   $ mergin status
+   ```
+2. pull changes from Mergin service
+   ```
+   $ mergin pull
+   ```
+3. push local changes to Mergin service
+   ```
+   $ mergin push
+   ```

--- a/mergin/__init__.py
+++ b/mergin/__init__.py
@@ -1,5 +1,5 @@
 from . import common
 
 from .client import MerginClient
-from .common import ClientError
+from .common import ClientError, LoginError
 from .merginproject import MerginProject, InvalidProject

--- a/mergin/common.py
+++ b/mergin/common.py
@@ -15,6 +15,14 @@ class ClientError(Exception):
     pass
 
 
+class LoginError(Exception):
+    pass
+
+
+class InvalidProject(Exception):
+    pass
+
+
 try:
     import dateutil.parser
     from dateutil.tz import tzlocal

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 from dateutil.tz import tzlocal
 
-from .common import UPLOAD_CHUNK_SIZE
+from .common import UPLOAD_CHUNK_SIZE, InvalidProject
 from .utils import generate_checksum, move_file, int_version, find, do_sqlite_checkpoint
 
 
@@ -20,10 +20,6 @@ try:
     from .deps import pygeodiff
 except ImportError:
     os.environ['GEODIFF_ENABLED'] = 'False'
-
-
-class InvalidProject(Exception):
-    pass
 
 
 class MerginProject:

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from setuptools import setup, find_packages
 
 setup(
     name='mergin-client',
-    version='dev',
-    url='',
+    version='2020.4.1',
+    url='https://github.com/lutraconsulting/mergin-py-client',
     license='MIT',
     author='Lutra Consulting Ltd.',
     author_email='mergin@lutraconsulting.co.uk',
@@ -19,8 +19,13 @@ setup(
     install_requires=[
         'python-dateutil==2.6.0',
         'pygeodiff==0.7.4',
-        'pytz==2019.3'
+        'pytz==2019.3',
+        'click',
     ],
+
+    entry_points={
+        'console_scripts': ['mergin=mergin.cli:cli'],
+    },
 
     test_suite='nose.collector',
     tests_require=['nose'],


### PR DESCRIPTION
- cli.py gets installed as a 'mergin' command line tool
- client has default URL defined, so it's not needed to always set it
- if initial download fails, the newly created directory gets removed again (otherwise subsequent download would fail due to existing dir)
- handle DNS resolution error when doing requests
- download - will raise exception if project does not have fully qualified form "xxx/yyy"
- mergin client code does not raise basic Exception - instead uses module-specific classes
- all mergin exceptions defined in a single module