### PR TITLE
Handle exception when copying files and src/dest paths are the same

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -463,7 +463,10 @@ class MerginProject:
                         if self.is_versioned_file(path):
                             os.remove(basefile)
                     else:
-                        shutil.copy(src, dest)
+                        try:
+                            shutil.copy(src, dest)
+                        except shutil.SameFileError:
+                            self.log.info(f"Skip copying - paths are identical: {src} and {dest}")
                         if self.is_versioned_file(path):
                             shutil.copy(src, basefile)
 


### PR DESCRIPTION
In apply_pull_changes of merginproject. See https://github.com/lutraconsulting/qgis-mergin-plugin/issues/219