### PR TITLE
Try to fix coveralls github action that fails to upload results

### DIFF
--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          coveralls
+          coveralls --service=github


### PR DESCRIPTION
Error says:
```
HTTPError: 422 Client Error: Unprocessable Entity for url: https://coveralls.io/api/v1/jobs
```

Fix according to:
https://stackoverflow.com/questions/65692711/using-python-coveralls-from-github-actions-returns-could-not-submit-coverage-4