### PR TITLE
Auth token recreation

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -395,7 +395,7 @@ def remove(project):
     """Remove project from server and locally (if exists)."""
     local_info = None
     if not project:
-        from mergin.client import inspect_project
+        from mergin.client import inspect_project  # TODO: no inspect_project defined in the client!
         try:
             local_info = inspect_project(os.path.join(os.getcwd()))
             project = local_info['name']

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -48,6 +48,7 @@ class MerginClient:
                 self._auth_session = {"token": auth_token, "expire": dateutil.parser.parse(token_data["expire"])}
                 self._user_info = {"username": token_data["username"]}
             except (ClientError, KeyError):
+                raise ClientError("Invalid token data")
                 pass  # Invalid token data - ignore it
         handlers = []
 
@@ -120,9 +121,9 @@ class MerginClient:
         def wrapper(self, *args):
             if self._auth_params:
                 if self._auth_session:
-                    # Refresh auth token if it expired or expires very soon
+                    # Refresh auth token if it expired or will expire very soon
                     delta = self._auth_session["expire"] - datetime.now(timezone.utc)
-                    if delta.total_seconds() < 24 * 3600:
+                    if delta.total_seconds() < 5:
                         self.login(self._auth_params["login"], self._auth_params["password"])
                 else:
                     # Create a new authorization token

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -1,5 +1,4 @@
 import logging
-from logging.handlers import RotatingFileHandler
 import os
 import json
 import zlib
@@ -277,6 +276,7 @@ class MerginClient:
                 info = json.load(e)
                 self.log.info(f"Login problem: {info.get('detail')}")
                 raise LoginError(info.get("detail"))
+            self.log.info(f"Login problem: {e.read().decode('utf-8')}")
             raise LoginError(e.read().decode("utf-8"))
         except urllib.error.URLError as e:
             # e.g. when DNS resolution fails (no internet connection?)

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -51,15 +51,7 @@ class MerginProject:
         if not os.path.exists(self.meta_dir):
             os.mkdir(self.meta_dir)
 
-        # setup logging into project directory's .mergin/client-log.txt file
-        self.log = logging.getLogger('mergin.project.' + directory)
-        self.log.setLevel(logging.DEBUG)   # log everything (it would otherwise log just warnings+errors)
-        if not self.log.handlers:
-            # we only need to set the handler once
-            # (otherwise we would get things logged multiple times as loggers are cached)
-            log_handler = logging.FileHandler(os.path.join(self.meta_dir, "client-log.txt"))
-            log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
-            self.log.addHandler(log_handler)
+        self.setup_logging(directory)
 
         # redirect any geodiff output to our log file
         if self.geodiff:
@@ -73,6 +65,25 @@ class MerginProject:
                     self.log.info("GEODIFF: " + text)
             self.geodiff.set_logger_callback(_logger_callback)
             self.geodiff.set_maximum_logger_level(pygeodiff.GeoDiff.LevelDebug)
+
+    def setup_logging(self, logger_name):
+        """Setup logging into project directory's .mergin/client-log.txt file."""
+        self.log = logging.getLogger('mergin.project.' + logger_name)
+        self.log.setLevel(logging.DEBUG)  # log everything (it would otherwise log just warnings+errors)
+        if not self.log.handlers:
+            # we only need to set the handler once
+            # (otherwise we would get things logged multiple times as loggers are cached)
+            log_handler = logging.FileHandler(os.path.join(self.meta_dir, "client-log.txt"))
+            log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+            self.log.addHandler(log_handler)
+
+    def remove_logging_handler(self):
+        """Check if there is a logger handler defined for the project and remove it. There should be only one."""
+        if len(self.log.handlers) > 0:
+            handler = self.log.handlers[0]
+            self.log.removeHandler(handler)
+            handler.flush()
+            handler.close()
 
     def fpath(self, file, other_dir=None):
         """

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -52,7 +52,7 @@ class MerginProject:
             os.mkdir(self.meta_dir)
 
         # setup logging into project directory's .mergin/client-log.txt file
-        self.log = logging.getLogger('mergin.' + directory)
+        self.log = logging.getLogger('mergin.project.' + directory)
         self.log.setLevel(logging.DEBUG)   # log everything (it would otherwise log just warnings+errors)
         if not self.log.handlers:
             # we only need to set the handler once

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 import shutil
@@ -826,3 +827,25 @@ def test_missing_local_file_pull(mc):
     # try to sync again  -- it should not crash
     mc.pull_project(project_dir)
     mc.push_project(project_dir)
+
+
+def test_logging(mc):
+    """Test logger creation with and w/out the env variable for log file."""
+    assert isinstance(mc.log.handlers[0], logging.NullHandler)
+    mc.log.info("Test info log...")
+    # remove the Null handler and set the env variable with the global log file path
+    mc.log.handlers = []
+    os.environ['MERGIN_CLIENT_LOG'] = os.path.join(TMP_DIR, 'global-mergin-log.txt')
+    assert os.environ.get('MERGIN_CLIENT_LOG', None) is not None
+    token = mc._auth_session['token']
+    mc1 = MerginClient(mc.url, auth_token=token)
+    assert isinstance(mc1.log.handlers[0], logging.FileHandler)
+    mc1.log.info("Test log info to the log file...")
+    # cleanup
+    mc.log.handlers = []
+    del os.environ['MERGIN_CLIENT_LOG']
+
+
+def test_server_compatibility(mc):
+    """Test server compatibility."""
+    assert mc.is_server_compatible()

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -58,6 +58,10 @@ def test_login(mc):
     token = mc._auth_session['token']
     assert MerginClient(mc.url, auth_token=token)
 
+    invalid_token = "Completely invalid token...."
+    with pytest.raises(TokenError, match=f"Token doesn't start with 'Bearer .': {invalid_token}"):
+        decode_token_data(invalid_token)
+
     invalid_token = "Bearer .jas646kgfa"
     with pytest.raises(TokenError, match=f"Invalid token data: {invalid_token}"):
         decode_token_data(invalid_token)
@@ -404,6 +408,7 @@ def test_list_of_push_changes(mc):
 
 
 def test_token_renewal(mc):
+    """Test token regeneration in case it has expired."""
     test_project = 'test_token_renewal'
     project = API_USER + '/' + test_project
     project_dir = os.path.join(TMP_DIR, test_project)  # primary project dir for updates

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 
-from ..client import MerginClient, ClientError, MerginProject, LoginError, decode_token_data
+from ..client import MerginClient, ClientError, MerginProject, LoginError, decode_token_data, TokenError
 from ..client_push import push_project_async, push_project_cancel
 from ..utils import generate_checksum
 
@@ -58,8 +58,9 @@ def test_login(mc):
     token = mc._auth_session['token']
     assert MerginClient(mc.url, auth_token=token)
 
-    with pytest.raises(ClientError, match='Invalid token data'):
-        decode_token_data("Bearer .jas646kgfa")
+    invalid_token = "Bearer .jas646kgfa"
+    with pytest.raises(TokenError, match=f"Invalid token data: {invalid_token}"):
+        decode_token_data(invalid_token)
 
     with pytest.raises(LoginError, match='Invalid username or password'):
         mc.login('foo', 'bar')


### PR DESCRIPTION
Fixes https://github.com/lutraconsulting/qgis-mergin-plugin/issues/191 

Also fixes invalid token type errors at MerginClient initialization: https://github.com/lutraconsulting/qgis-mergin-plugin/issues/186
I am still investigating how an invalid token would happen, but this should allow users for seamless token recreation in case it is invalid.

Also fixes https://github.com/lutraconsulting/qgis-mergin-plugin/issues/170 by proper logging file handler removal before deleting a Mergin project directory.