### PR TITLE
Add tests to verify that rebase is working correctly

### DIFF
--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -16,7 +16,6 @@ import concurrent.futures
 
 from .common import UPLOAD_CHUNK_SIZE, ClientError
 from .merginproject import MerginProject
-from .utils import generate_checksum, do_sqlite_checkpoint
 
 
 class UploadJob:

--- a/mergin/test/sqlite_con.py
+++ b/mergin/test/sqlite_con.py
@@ -1,0 +1,15 @@
+"""
+A script to be used with AnotherSqliteConn in test_client.py to simulate
+an open connection to a sqlite3 database from a different process.
+"""
+
+import sqlite3
+import sys
+
+con = sqlite3.connect(sys.argv[1])
+cursor = con.cursor()
+while True:
+    cmd = input()
+    sys.stderr.write(cmd + "\n")
+    if cmd == 'stop': break
+    cursor.execute(cmd)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -848,12 +848,12 @@ def _is_file_updated(filename, changes_dict):
     return False
 
 
-def test_gpkg_change_without_geodiff(mc):
+def test_push_gpkg_schema_change(mc):
     """ Test that changes in GPKG get picked up if there were recent changes to it by another
     client and at the same time geodiff fails to find changes (a new table is added)
     """
 
-    test_project = 'test_gpkg_change'
+    test_project = 'test_push_gpkg_schema_change'
     project = API_USER + '/' + test_project
     project_dir = os.path.join(TMP_DIR, test_project)
     test_gpkg = os.path.join(project_dir, 'test.gpkg')

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -411,7 +411,6 @@ def test_force_gpkg_update(mc):
     project_info = mc.project_info(project)
     assert project_info['version'] == 'v2'
     f_remote = next((f for f in project_info['files'] if f['path'] == f_updated), None)
-    assert f_remote['checksum'] == updated_checksum
     assert 'diff' not in f_remote
 
 


### PR DESCRIPTION
New tests:
- when rebase is successful
- when rebase fails because local gpkg got schema changed
- when rebase fails because remote gpkg got schema changed

The tests are parametrized to check also the case when there is a pending
sqlite connection to gpkg (e.g. layer open in QGIS), to make sure things work
correctly in that case too (no sync failures / data corruption or loss).

Ensures that #96 and https://github.com/lutraconsulting/qgis-mergin-plugin/issues/246 are fixed now (thanks to fix for #30)