### PR TITLE
prevent logging errors with unicode

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -68,7 +68,7 @@ class MerginProject:
         if not self.log.handlers:
             # we only need to set the handler once
             # (otherwise we would get things logged multiple times as loggers are cached)
-            log_handler = logging.FileHandler(os.path.join(self.meta_dir, "client-log.txt"))
+            log_handler = logging.FileHandler(os.path.join(self.meta_dir, "client-log.txt"), encoding = 'utf-8')
             log_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
             self.log.addHandler(log_handler)
 


### PR DESCRIPTION
When a file has some special unicode characters in its name (ex: é), logging cannot write the corresponding log message (ex: Message: 'Downloading filewithunicode.gpkg version=vXXX diff=False part=0') to the log file and it prints a massive error message to the terminal. 

Solution suggested is to add utf8 to the encoding parameter of logging FileHandler

`--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\hp\anaconda3\envs\mm\lib\logging\__init__.py", line 1086, in emit
    stream.write(msg + self.terminator)
  File "C:\Users\hp\anaconda3\envs\mm\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u0301' in position 58: character maps to <undefined>
Call stack:
  File "C:\Users\hp\anaconda3\envs\mm\lib\threading.py", line 930, in _bootstrap
    self._bootstrap_inner()
  File "C:\Users\hp\anaconda3\envs\mm\lib\threading.py", line 973, in _bootstrap_inner
    self.run()
  File "C:\Users\hp\anaconda3\envs\mm\lib\threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\hp\anaconda3\envs\mm\lib\concurrent\futures\thread.py", line 83, in _worker
    work_item.run()
  File "C:\Users\hp\anaconda3\envs\mm\lib\concurrent\futures\thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "C:\Users\hp\anaconda3\envs\mm\lib\site-packages\mergin\client_pull.py", line 90, in _do_download    item.download_blocking(mc, mp, project_path)
  File "C:\Users\hp\anaconda3\envs\mm\lib\site-packages\mergin\client_pull.py", line 282, in download_blocking
    mp.log.debug(f"Downloading {self.file_path} version={self.version} diff={self.diff_only} part={self.part_index}")
Message: 'Downloading SOME_SPECIAL_UNICODE_CHARS.gpkg version=vXXX diff=False part=0'
Arguments: ()`