### PR TITLE
Handle rebase failure (refs #117)

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -742,6 +742,13 @@ class MerginClient:
         """
         Test whether project has an unfinished pull.
 
+        Unfinished pull means that a previous pull_project() call has
+        failed in the final stage due to some files being in read-only
+        mode. When a project has unfinished pull, it has to be resolved
+        before allowing further pulls or pushes.
+
+        .. seealso:: self.resolve_unfinished_pull
+
         :param directory: project's directory
         :type directory: String
         :returns: project has unfinished pull
@@ -754,6 +761,17 @@ class MerginClient:
     def resolve_unfinished_pull(self, directory):
         """
         Try to resolve unfinished pull.
+
+        Unfinished pull means that a previous pull_project() call has
+        failed in the final stage due to some files being in read-only
+        mode. When a project has unfinished pull, it has to be resolved
+        before allowing further pulls or pushes.
+
+        To resolving unfinihed pull includes creation of conflicted copy
+        and replacement of the original file by the new version from the
+        server.
+
+        .. seealso:: self.has_unfinished_pull
 
         :param directory: project's directory
         :type directory: String

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -759,4 +759,4 @@ class MerginClient:
         :type directory: String
         """
         mp = MerginProject(directory)
-        mp.resolve_unfinished_pull()
+        mp.resolve_unfinished_pull(self.username())

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -737,3 +737,26 @@ class MerginClient:
         job = download_diffs_async(self, project_dir, file_path, version_from, version_to)
         pull_project_wait(job)
         download_diffs_finalize(job, output_diff)
+
+    def has_unfinished_pull(self, directory):
+        """
+        Test whether project has an unfinished pull.
+
+        :param directory: project's directory
+        :type directory: String
+        :returns: project has unfinished pull
+        rtype: Boolean
+        """
+        mp = MerginProject(directory)
+
+        return mp.has_unfinished_pull()
+
+    def resolve_unfinished_pull(self, directory):
+        """
+        Try to resolve unfinished pull.
+
+        :param directory: project's directory
+        :type directory: String
+        """
+        mp = MerginProject(directory)
+        mp.resolve_unfinished_pull()

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -343,6 +343,14 @@ def pull_project_async(mc, directory):
     """
 
     mp = MerginProject(directory)
+    if mp.has_unfinished_pull():
+        try:
+            mp.resolve_unfinished_pull(mc.username())
+        except ClientError as err:
+            mp.log.error("Error resolving unfinished pull: " + str(err))
+            mp.log.info("--- pull aborted")
+            raise
+
     project_path = mp.metadata["name"]
     local_version = mp.metadata["version"]
 

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -566,16 +566,16 @@ def pull_project_finalize(job, user_name):
             raise ClientError("Cannot patch basefile {}! Please try syncing again.".format(basefile))
 
     conflicts = job.mp.apply_pull_changes(job.pull_changes, job.temp_dir, user_name)
-    if not job.mp.has_unfinished_pull():
-        job.mp.metadata = {
-            'name': job.project_path,
-            'version': job.version if job.version else "v0",  # for new projects server version is ""
-            'files': job.project_info['files']
-        }
+    job.mp.metadata = {
+        'name': job.project_path,
+        'version': job.version if job.version else "v0",  # for new projects server version is ""
+        'files': job.project_info['files']
+    }
 
-        job.mp.log.info("--- pull finished -- at version " + job.mp.metadata['version'])
-    else:
+    if job.mp.has_unfinished_pull():
         job.mp.log.info("--- failed to complete pull -- project left in the unfinished pull state")
+    else:
+        job.mp.log.info("--- pull finished -- at version " + job.mp.metadata['version'])
 
     shutil.rmtree(job.temp_dir)
     return conflicts

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -566,13 +566,16 @@ def pull_project_finalize(job, user_name):
             raise ClientError("Cannot patch basefile {}! Please try syncing again.".format(basefile))
 
     conflicts = job.mp.apply_pull_changes(job.pull_changes, job.temp_dir, user_name)
-    job.mp.metadata = {
-        'name': job.project_path,
-        'version': job.version if job.version else "v0",  # for new projects server version is ""
-        'files': job.project_info['files']
-    }
+    if not job.mp.has_unfinished_pull():
+        job.mp.metadata = {
+            'name': job.project_path,
+            'version': job.version if job.version else "v0",  # for new projects server version is ""
+            'files': job.project_info['files']
+        }
 
-    job.mp.log.info("--- pull finished -- at version " + job.mp.metadata['version'])
+        job.mp.log.info("--- pull finished -- at version " + job.mp.metadata['version'])
+    else:
+        job.mp.log.info("--- failed to complete pull -- project left in the unfinished pull state")
 
     shutil.rmtree(job.temp_dir)
     return conflicts

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -709,3 +709,4 @@ class MerginProject:
 
         shutil.rmtree(self.unfinished_pull_dir)
         self.log.info("unfinished pull resolved successfuly!")
+        return

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -656,7 +656,7 @@ class MerginProject:
         """
         return os.path.exists(self.pull_dir)
 
-    def resolve_unfinshed_pull(self):
+    def resolve_unfinished_pull(self):
         """
         Try to resolve unfinished pull.
         """

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -403,9 +403,8 @@ class MerginProject:
         :type changes: dict[str, list[dict]]
         :param temp_dir: directory with downloaded files from server
         :type temp_dir: str
-        :returns: tuple containig list of files where conflicts were found and boolean flag indicating
-        whether pull was successful or not
-        :rtype: tuple(list[str], bool)
+        :returns: files where conflicts were found
+        :rtype: list[str]
         """
         conflicts = []
         unfinished = False
@@ -457,7 +456,7 @@ class MerginProject:
                         else:
                             shutil.copy(src, dest)
 
-        return conflicts, unfinished
+        return conflicts
 
     def update_with_rebase(self, path, src, dest, basefile, temp_dir, user_name):
         """
@@ -477,9 +476,8 @@ class MerginProject:
         :type basefile: str
         :param temp_dir: directory with downloaded files from server
         :type temp_dir: str
-        :returns: tuple containing path to conflict file if rebase fails, empty string on success
-        and boolean flag indicating whether pull finished or unfinished
-        :rtype: tuple(str, bool)
+        :returns: path to conflict file if rebase fails, empty string on success
+        :rtype: str
         """
         self.log.info("updating file with rebase: " + path)
 
@@ -507,8 +505,6 @@ class MerginProject:
         rebase_conflicts = unique_path_name(
                 edit_conflict_file_name(self.fpath(path), user_name, int_version(self.metadata['version'])))
 
-        unfinished = False
-
         # try to do rebase magic
         try:
             self.geodiff.create_changeset(basefile, src, server_diff)
@@ -525,14 +521,13 @@ class MerginProject:
                 # original file synced with server
                 self.geodiff.make_copy_sqlite(f_server_backup, basefile)
                 self.geodiff.make_copy_sqlite(f_server_backup, dest)
-                return conflict, unfinished
+                return conflict
             except pygeodiff.GeoDiffLibError as err:
                 self.log.warning("sync with server failed! going to create an unfinished pull")
                 f_server_unfinished = self.fpath_pull(path)
                 self.geodiff.make_copy_sqlite(f_server_backup, f_server_unfinished)
-                unfinished = True
 
-        return '', unfinished
+        return ''
 
     def update_without_rebase(self, path, src, dest, basefile, temp_dir):
         """

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -651,3 +651,11 @@ class MerginProject:
                 error = str(e)
                 break
         return error
+
+    def has_unfinished_pull(self):
+        """ Check if there is an unfinished pull for this project.
+
+        :returns: whether there is an unfinished pull
+        :rtype: bool
+        """
+        return os.path.exists(self.pull_dir)


### PR DESCRIPTION
Implement approach described in #117.

If the rebase fails and copy of the database file fails too (common on Windows), keep an extra directory `unfinished_pull` inside `.mergin` dir with the files we need to copy but we were unable to do because the files were locked by OS.

New methods added:
- `has_unfinished_pull` - checks whether there is an unfinished pull
- `resolve_unfinished_pull` - try to apply changes from unfinished pull