### PR TITLE
use unique file names for conflict files (fixes #62)

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -614,7 +614,7 @@ class MerginClient:
         if job is None:
             return   # project is up to date
         pull_project_wait(job)
-        return pull_project_finalize(job, self._auth_params['login'])
+        return pull_project_finalize(job, self.username())
 
     def clone_project(self, source_project_path, cloned_project_name, cloned_project_namespace=None):
         """

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -614,7 +614,7 @@ class MerginClient:
         if job is None:
             return   # project is up to date
         pull_project_wait(job)
-        return pull_project_finalize(job)
+        return pull_project_finalize(job, self._auth_params['login'])
 
     def clone_project(self, source_project_path, cloned_project_name, cloned_project_namespace=None):
         """

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -14,8 +14,8 @@ from ..client_push import push_project_async, push_project_cancel
 from ..utils import (
     generate_checksum,
     get_versions_with_file_changes,
-    unique_file_name,
-    conflict_copy_file_name,
+    unique_path_name,
+    conflicted_copy_file_name,
     edit_conflict_file_name
 )
 from ..merginproject import pygeodiff
@@ -220,8 +220,8 @@ def test_push_pull_changes(mc):
     assert not os.path.exists(os.path.join(project_dir_2, f_removed))
     assert not os.path.exists(os.path.join(project_dir_2, f_renamed))
     assert os.path.exists(os.path.join(project_dir_2, 'renamed.txt'))
-    assert os.path.exists(os.path.join(project_dir_2, conflict_copy_file_name(f_updated, API_USER, 1)))
-    assert generate_checksum(os.path.join(project_dir_2, conflict_copy_file_name(f_updated, API_USER, 1))) == f_conflict_checksum
+    assert os.path.exists(os.path.join(project_dir_2, conflicted_copy_file_name(f_updated, API_USER, 1)))
+    assert generate_checksum(os.path.join(project_dir_2, conflicted_copy_file_name(f_updated, API_USER, 1))) == f_conflict_checksum
     assert generate_checksum(os.path.join(project_dir_2, f_updated)) == f_remote_checksum
 
 
@@ -1141,7 +1141,7 @@ def test_rebase_local_schema_change(mc, extra_connection):
     project_dir_2 = os.path.join(TMP_DIR, test_project+'_2')  # concurrent project dir
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
+    test_gpkg_conflict = conflicted_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)
@@ -1207,7 +1207,7 @@ def test_rebase_remote_schema_change(mc, extra_connection):
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_2 = os.path.join(project_dir_2, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
+    test_gpkg_conflict = conflicted_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)
@@ -1272,7 +1272,7 @@ def test_rebase_success(mc, extra_connection):
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_2 = os.path.join(project_dir_2, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
+    test_gpkg_conflict = conflicted_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)
@@ -1331,7 +1331,7 @@ def test_conflict_file_names():
            ]
 
     for i in data:
-        file_name = conflict_copy_file_name(i[0], i[1], i[2])
+        file_name = conflicted_copy_file_name(i[0], i[1], i[2])
         assert file_name == i[3]
 
 
@@ -1354,7 +1354,7 @@ def test_conflict_file_names():
         assert file_name == i[3]
 
 
-def test_unique_file_names():
+def test_unique_path_names():
     """
     Test generation of unique file names.
     """
@@ -1395,7 +1395,7 @@ def test_unique_file_names():
             ('folderA/folderAB', 'folderA/folderAB (2)'),
            ]
     for i in data:
-        file_name = unique_file_name(os.path.join(project_dir, i[0]))
+        file_name = unique_path_name(os.path.join(project_dir, i[0]))
         assert file_name == os.path.join(project_dir, i[1])
 
 

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -220,8 +220,8 @@ def test_push_pull_changes(mc):
     assert not os.path.exists(os.path.join(project_dir_2, f_removed))
     assert not os.path.exists(os.path.join(project_dir_2, f_renamed))
     assert os.path.exists(os.path.join(project_dir_2, 'renamed.txt'))
-    assert os.path.exists(os.path.join(project_dir_2, f_updated+'_conflict_copy'))
-    assert generate_checksum(os.path.join(project_dir_2, f_updated+'_conflict_copy')) == f_conflict_checksum
+    assert os.path.exists(os.path.join(project_dir_2, conflict_copy_file_name(f_updated, API_USER, 1)))
+    assert generate_checksum(os.path.join(project_dir_2, conflict_copy_file_name(f_updated, API_USER, 1))) == f_conflict_checksum
     assert generate_checksum(os.path.join(project_dir_2, f_updated)) == f_remote_checksum
 
 
@@ -1141,7 +1141,7 @@ def test_rebase_local_schema_change(mc, extra_connection):
     project_dir_2 = os.path.join(TMP_DIR, test_project+'_2')  # concurrent project dir
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = test_gpkg + '_conflict_copy'
+    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)
@@ -1207,7 +1207,7 @@ def test_rebase_remote_schema_change(mc, extra_connection):
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_2 = os.path.join(project_dir_2, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = test_gpkg + '_conflict_copy'
+    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)
@@ -1272,7 +1272,7 @@ def test_rebase_success(mc, extra_connection):
     test_gpkg = os.path.join(project_dir, 'test.gpkg')
     test_gpkg_2 = os.path.join(project_dir_2, 'test.gpkg')
     test_gpkg_basefile = os.path.join(project_dir, '.mergin', 'test.gpkg')
-    test_gpkg_conflict = test_gpkg + '_conflict_copy'
+    test_gpkg_conflict = conflict_copy_file_name(test_gpkg, API_USER, 1)
     cleanup(mc, project, [project_dir, project_dir_2])
 
     os.makedirs(project_dir)

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -148,7 +148,7 @@ def get_versions_with_file_changes(
     return [f"v{ver_nr}" for ver_nr in all_version_numbers[idx_from:idx_to + 1]]
 
 
-def unique_file_name(path):
+def unique_path_name(path):
     """
     Generates an unique name for the given path. If the given path does
     not exist yet it will be returned unchanged, otherwise a sequntial
@@ -180,7 +180,7 @@ def unique_file_name(path):
     return unique_path
 
 
-def conflict_copy_file_name(path, user, version):
+def conflicted_copy_file_name(path, user, version):
     """
     Generates a file name for the conflict copy file in the following form
     <filename> (conflicted copy, <username> v<version>).gpkg. Example:


### PR DESCRIPTION
Apply new naming scheme for conflict files:

-   `my data (conflicted copy, martin v10).gpkg` - for full copy (when rebase fails)
-   `my data (edit conflict, martin v10).json` - for list of edit conflicts upon rebase (always a JSON file)

Fixes #62.