### PR TITLE
Report tool

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -701,8 +701,6 @@ def download_diffs_async(mc, project_directory, file_path, versions):
         mp.log.info("--- downloading diffs aborted")
         raise
 
-    download_dir = os.path.join(mp.meta_dir, ".cache")
-    os.makedirs(download_dir, exist_ok=True)
     fetch_files = []
 
     for version in versions:
@@ -718,8 +716,8 @@ def download_diffs_async(mc, project_directory, file_path, versions):
     download_list = []  # list of all items to be downloaded
     total_size = 0
     for file in fetch_files:
-        items = _download_items(file, download_dir, diff_only=True)
-        dest_file_path = os.path.normpath(os.path.join(download_dir, file["version"] + "-" + file['diff']['path']))
+        items = _download_items(file, mp.cache_dir, diff_only=True)
+        dest_file_path = mp.fpath_cache(file['diff']['path'], version=file["version"])
         if os.path.exists(dest_file_path):
             continue
         files_to_merge.append(FileToMerge(dest_file_path, items))
@@ -729,7 +727,7 @@ def download_diffs_async(mc, project_directory, file_path, versions):
 
     mp.log.info(f"will download {len(download_list)} chunks, total size {total_size}")
 
-    job = PullJob(project_path, None, total_size, None, files_to_merge, download_list, download_dir, mp,
+    job = PullJob(project_path, None, total_size, None, files_to_merge, download_list, mp.cache_dir, mp,
                   server_info, {}, mc.username())
 
     # start download

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -707,6 +707,8 @@ def download_diffs_async(mc, project_directory, file_path, versions):
 
     for version in versions:
         version_data = file_history["history"][version]
+        if "diff" not in version_data:
+            continue  # skip if there is no diff in history
         diff_data = copy.deepcopy(version_data)
         diff_data['version'] = version
         diff_data['diff'] = version_data['diff']

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -52,6 +52,10 @@ class MerginProject:
         # location for files from unfinished pull
         self.unfinished_pull_dir = os.path.join(self.meta_dir, 'unfinished_pull')
 
+        self.cache_dir = os.path.join(self.meta_dir, '.cache')
+        if not os.path.exists(self.cache_dir):
+            os.mkdir(self.cache_dir)
+
         self.setup_logging(directory)
 
         # make sure we can load correct pygeodiff
@@ -118,6 +122,14 @@ class MerginProject:
     def fpath_unfinished_pull(self, file):
         """ Helper function to get absolute path of file in unfinished_pull dir. """
         return self.fpath(file, self.unfinished_pull_dir)
+
+    def fpath_cache(self, file, version=None):
+        """ Helper function to get absolute path of file in cache dir.
+        It can be either in root cache directory (.mergin/.cache/) or in some version's subfolder
+        """
+        if version:
+            return self.fpath(file, os.path.join(self.cache_dir, version))
+        return self.fpath(file, self.cache_dir)
 
     @property
     def metadata(self):

--- a/mergin/report.py
+++ b/mergin/report.py
@@ -1,0 +1,237 @@
+import csv
+import json
+import os
+import tempfile
+from collections import defaultdict
+from itertools import groupby
+
+from . import ClientError
+from .merginproject import MerginProject, pygeodiff
+from .utils import int_version
+
+
+# inspired by C++ implementation https://github.com/lutraconsulting/geodiff/blob/master/geodiff/src/drivers/sqliteutils.cpp
+# in geodiff lib (MIT licence)
+# ideally there should be pygeodiff api for it
+def parse_gpkgb_header_size(gpkg_wkb):
+    """ Parse header of geopackage wkb and return its size """
+    # some constants
+    no_envelope_header_size = 8
+    flag_byte_pos = 3
+    envelope_size_mask = 14
+
+    try:
+        flag_byte = gpkg_wkb[flag_byte_pos]
+    except IndexError:
+        return -1  # probably some invalid input
+    envelope_byte = (flag_byte & envelope_size_mask) >> 1
+    envelope_size = 0
+
+    if envelope_byte == 1:
+        envelope_size = 32
+    elif envelope_byte == 2:
+        envelope_size = 48
+    elif envelope_byte == 3:
+        envelope_size = 48
+    elif envelope_byte == 4:
+        envelope_size = 64
+
+    return no_envelope_header_size + envelope_size
+
+
+class ChangesetReportEntry:
+    """ Derivative of geodiff ChangesetEntry suitable for further processing/reporting """
+    def __init__(self, changeset_entry, geom_idx, geom):
+        self.table = changeset_entry.table.name
+        self.geom_type = geom["type"]
+        self.crs = geom["srs_id"]
+
+        if changeset_entry.operation == changeset_entry.OP_DELETE:
+            self.operation = "delete"
+            self.old_geom = changeset_entry.old_values[geom_idx]
+            self.new_geom = None
+        elif changeset_entry.operation == changeset_entry.OP_UPDATE:
+            self.operation = "update"
+            self.old_geom = changeset_entry.old_values[geom_idx]
+            self.new_geom = changeset_entry.new_values[geom_idx]
+        elif changeset_entry.operation == changeset_entry.OP_INSERT:
+            self.operation = "insert"
+            self.old_geom = None
+            self.new_geom = changeset_entry.new_values[geom_idx]
+
+        self.count = None
+        self.length = None
+        self.area = None
+
+        if self.geom_type == "LINESTRING":
+            # we calculate change in length, for attributes changes only we set to 0
+            self.metric = "length"
+            if self.operation == "delete":
+                self.length = self.measure(self.old_geom)
+            elif self.operation == "update":
+                self.length = self.measure(self.new_geom) - self.measure(self.old_geom)
+            elif self.operation == "insert":
+                self.length = self.measure(self.new_geom)
+        elif self.geom_type == "POLYGON":
+            # we calculate change in area, for attributes changes only we set to 0
+            self.metric = "area"
+            if self.operation == "delete":
+                self.area = self.measure(self.old_geom)
+            elif self.operation == "update":
+                self.area = self.measure(self.new_geom) - self.measure(self.old_geom)
+            elif self.operation == "insert":
+                self.area = self.measure(self.new_geom)
+        else:
+            # regardless of geometry change count as 1
+            self.metric = "count"
+            self.count = 1
+
+    def measure(self, geom):
+        """ Return length or area of geometry based on type """
+        # calculate geom length/area only if QGIS API is available
+        try:
+            from qgis.core import QgsGeometry, QgsDistanceArea, QgsCoordinateReferenceSystem, QgsCoordinateTransformContext
+        except ImportError:
+            return -1
+
+        d = QgsDistanceArea()
+        d.setEllipsoid('WGS84')
+        crs = QgsCoordinateReferenceSystem()
+        crs.createFromString(self.crs)
+        d.setSourceCrs(crs, QgsCoordinateTransformContext())
+        g = QgsGeometry()
+        wkb_header_length = parse_gpkgb_header_size(geom)
+        wkb_geom = geom[wkb_header_length:]
+        g.fromWkb(wkb_geom)
+        if self.metric == "length":
+            return d.measureLength(g)
+        elif self.metric == "area":
+            return d.measureArea(g)
+        else:
+            return 1
+
+
+class ChangesetReport:
+    """ Report (aggregate) from geopackage changeset (diff file) """
+    def __init__(self, changeset_reader, schema):
+        self.cr = changeset_reader
+        self.schema = schema
+        self.entries = []
+        # let's iterate through reader and populate entries
+        for entry in self.cr:
+            schema_table = next((t for t in schema if t["table"] == entry.table.name), None)
+            # get geometry index in both gpkg schema and diffs values
+            geom_idx = next((index for (index, col) in enumerate(schema_table["columns"]) if col["type"] == "geometry"),
+                            None)
+            if not geom_idx:
+                continue
+
+            geom_col = schema_table["columns"][geom_idx]["geometry"]
+            report_entry = ChangesetReportEntry(entry, geom_idx, geom_col)
+            self.entries.append(report_entry)
+
+    def report(self):
+        """ Aggregate entries by table and operation type and calculate quantity """
+        records = []
+        tables = defaultdict(list)
+
+        for obj in self.entries:
+            tables[obj.table].append(obj)
+
+        for table, entries in tables.items():
+            items = groupby(entries, lambda i: (i.operation, i.metric))
+            for k, v in items:
+                quantity_type = "_".join(k)
+                values = list(v)
+                quantity = sum([getattr(entry, k[1]) for entry in values])
+                records.append({
+                    "table": table,
+                    "quantity_type": quantity_type,
+                    "quantity": quantity
+                })
+        return records
+
+
+def create_report(mc, directory, project, since, to, out_dir=tempfile.gettempdir()):
+    """ Creates report from geodiff changesets for a range of project versions in CSV format.
+
+    Args:
+        mc (MerginClient): MerginClient instance.
+        directory (str): local project directory (must already exist).
+        project (str): full project name (<namespace/project>).
+        since (str): starting project version tag, for example 'v3'.
+        to (str): ending project version tag, for example 'v6'.
+        out_dir (str): output directory to save report.csv in, defaults to temp dir
+    """
+    mp = MerginProject(directory)
+    mp.log.info(f"--- Creating changesets report for {project} from {since} to {to} versions ----")
+    versions_map = {v["name"]: v for v in mc.project_versions(project, since, to)["versions"]}
+    headers = ["file", "table", "author", "timestamp", "version", "quantity_type", "quantity"]
+    records = []
+    info = mc.project_info(project, since=since)
+    # filter only .gpkg files
+    files = [f for f in info["files"] if mp.is_versioned_file(f["path"])]
+    for f in files:
+        mp.log.debug(f"analyzing {f['path']} ...")
+        diff_file = os.path.join(mp.meta_dir, f["path"] + ".diff")
+        try:
+            if "history" not in f:
+                continue
+
+            # download diffs in desired range, in case versions are not within history,
+            # pass unknown, and it will be determined in download function
+            # it can be different for each file
+            since_ = since if since in f["history"] else None
+            to_ = to if to in f["history"] else None
+            if not (since_ and to_):
+                continue  # no change at all for particular file in desired range
+
+            mc.get_file_diff(directory, f["path"], diff_file, since_, to_, True)
+
+            # download full gpkg in "to" version to analyze its schema to determine which col is geometry
+            full_gpkg = os.path.join(mp.meta_dir, ".cache", f["path"])
+            if not os.path.exists(full_gpkg):
+                mc.download_file(directory, f["path"], full_gpkg, to)
+
+            # get gpkg schema
+            schema_file = full_gpkg + '-schema'  # geodiff writes schema into a file
+            if not os.path.exists(schema_file):
+                mp.geodiff.schema("sqlite", "", full_gpkg, schema_file)
+            with open(schema_file, 'r') as sf:
+                schema = json.load(sf).get("geodiff_schema")
+
+            # add records for every version (diff) and all tables within geopackage
+            for idx in range(int_version(since) + 1, int_version(to) + 1):
+                version = "v" + str(idx)
+                # skip version if there was no diff file
+                if version not in f['history']:
+                    continue
+                v_diff_file = os.path.join(mp.meta_dir, '.cache',
+                                           version + "-" + os.path.basename(f['history'][version]['diff']['path']))
+
+                version_data = versions_map[version]
+                cr = mp.geodiff.read_changeset(v_diff_file)
+                rep = ChangesetReport(cr, schema)
+                report = rep.report()
+                # append version info to changeset info
+                version_fields = {
+                    "file": f["path"],
+                    "author": version_data["author"],
+                    "timestamp": version_data["created"],
+                    "version": version_data["name"]
+                }
+                for row in report:
+                    records.append({**row, **version_fields})
+            mp.log.debug(f"done")
+        except (ClientError, pygeodiff.GeoDiffLibError) as e:
+            mp.log.warning(f"Skipping from report {f['path']}, issue found: {str(e)}")
+            raise ClientError("Reporting failed, please check log for details")
+
+    # export report to csv file
+    proj_name = project.replace(os.path.sep, "-")
+    report_file = os.path.join(out_dir, f'report-{proj_name}-{since}-{to}.csv')
+    with open(report_file, 'w', newline='') as f_csv:
+        writer = csv.DictWriter(f_csv, fieldnames=headers)
+        writer.writeheader()
+        writer.writerows(records)
+    mp.log.info(f"--- Report saved to {report_file} ----")

--- a/mergin/report.py
+++ b/mergin/report.py
@@ -86,10 +86,14 @@ class ChangesetReportEntry:
 
         if hasattr(changeset_entry, "old_values"):
             old_wkb = changeset_entry.old_values[geom_idx]
+            if isinstance(old_wkb, pygeodiff.UndefinedValue):
+                old_wkb = None
         else:
             old_wkb = None
         if hasattr(changeset_entry, "new_values"):
             new_wkb = changeset_entry.new_values[geom_idx]
+            if isinstance(new_wkb, pygeodiff.UndefinedValue):
+                new_wkb = None
         else:
             new_wkb = None
 

--- a/mergin/report.py
+++ b/mergin/report.py
@@ -165,7 +165,7 @@ def create_report(mc, directory, project, since, to, out_dir=tempfile.gettempdir
     """
     mp = MerginProject(directory)
     mp.log.info(f"--- Creating changesets report for {project} from {since} to {to} versions ----")
-    versions_map = {v["name"]: v for v in mc.project_versions(project, since, to)["versions"]}
+    versions_map = {v["name"]: v for v in mc.project_versions(project, since, to)}
     headers = ["file", "table", "author", "timestamp", "version", "quantity_type", "quantity"]
     records = []
     info = mc.project_info(project, since=since)

--- a/mergin/report.py
+++ b/mergin/report.py
@@ -167,18 +167,18 @@ class ChangesetReport:
         return records
 
 
-def create_report(mc, directory, project, since, to, out_dir=tempfile.gettempdir()):
+def create_report(mc, directory, since, to, out_file):
     """ Creates report from geodiff changesets for a range of project versions in CSV format.
 
     Args:
         mc (MerginClient): MerginClient instance.
         directory (str): local project directory (must already exist).
-        project (str): full project name (<namespace/project>).
         since (str): starting project version tag, for example 'v3'.
         to (str): ending project version tag, for example 'v6'.
-        out_dir (str): output directory to save report.csv in, defaults to temp dir
+        out_file (str): output file to save csv in
     """
     mp = MerginProject(directory)
+    project = mp.metadata["name"]
     mp.log.info(f"--- Creating changesets report for {project} from {since} to {to} versions ----")
     versions_map = {v["name"]: v for v in mc.project_versions(project, since, to)}
     headers = ["file", "table", "author", "date", "time", "version", "operation", "length", "area", "count"]
@@ -245,10 +245,10 @@ def create_report(mc, directory, project, since, to, out_dir=tempfile.gettempdir
             raise ClientError("Reporting failed, please check log for details")
 
     # export report to csv file
-    proj_name = project.replace(os.path.sep, "-")
-    report_file = os.path.join(out_dir, f'report-{proj_name}-{since}-{to}.csv')
-    with open(report_file, 'w', newline='') as f_csv:
+    out_dir = os.path.dirname(out_file)
+    os.makedirs(out_dir, exist_ok=True)
+    with open(out_file, 'w', newline='') as f_csv:
         writer = csv.DictWriter(f_csv, fieldnames=headers)
         writer.writeheader()
         writer.writerows(records)
-    mp.log.info(f"--- Report saved to {report_file} ----")
+    mp.log.info(f"--- Report saved to {out_file} ----")

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -123,7 +123,7 @@ def test_create_remote_project_from_local(mc):
     assert project_info['name'] == test_project
     assert project_info['namespace'] == API_USER
 
-    versions = mc.project_versions(project)
+    versions = mc.project_versions(project)["versions"]
     assert len(versions) == 1
     assert versions[0]['name'] == 'v1'
     assert any(f for f in versions[0]['changes']['added'] if f['path'] == 'test.qgs')
@@ -193,7 +193,7 @@ def test_push_pull_changes(mc):
     assert generate_checksum(os.path.join(project_dir, f_updated)) == f_remote_checksum
     mp = MerginProject(project_dir)
     assert len(project_info['files']) == len(mp.inspect_files())
-    project_versions = mc.project_versions(project)
+    project_versions = mc.project_versions(project)["versions"]
     assert len(project_versions) == 2
     f_change = next((f for f in project_versions[0]['changes']['updated'] if f['path'] == f_updated), None)
     assert 'origin_checksum' not in f_change  # internal client info

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -196,7 +196,7 @@ def test_push_pull_changes(mc):
     assert len(project_info['files']) == len(mp.inspect_files())
     project_versions = mc.project_versions(project)
     assert len(project_versions) == 2
-    f_change = next((f for f in project_versions[0]['changes']['updated'] if f['path'] == f_updated), None)
+    f_change = next((f for f in project_versions[-1]['changes']['updated'] if f['path'] == f_updated), None)
     assert 'origin_checksum' not in f_change  # internal client info
 
     # test parallel changes
@@ -1642,8 +1642,3 @@ def test_report(mc):
         assert "v3,update_count,2" in content
         # files not edited are not in reports
         assert "inserted_1_A.gpkg" not in content
-
-    # test some failure, e.g. wrong version range, which would fail on getting version list
-    with pytest.raises(ClientError) as e:
-        create_report(mc, directory, project, to, since, TMP_DIR)
-    assert "The requested URL was not found on the server." in str(e.value)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1637,8 +1637,9 @@ def test_report(mc):
     # assert headers and content in report file
     with open(report_file, "r") as rf:
         content = rf.read()
-        assert ",".join(["file", "table", "author", "timestamp", "version", "quantity_type", "quantity"]) in content
+        headers = ",".join(["file", "table", "author", "date", "time", "version", "operation", "length", "area", "count"])
+        assert headers in content
         assert "base.gpkg,simple,test_plugin" in content
-        assert "v3,update_count,2" in content
+        assert "v3,update,,,2" in content
         # files not edited are not in reports
         assert "inserted_1_A.gpkg" not in content


### PR DESCRIPTION
This PR adds reporting functionality to export changesets aggregates for mergin projects in given version range to a csv file. It is a prerequisite for https://github.com/lutraconsulting/qgis-mergin-plugin/issues/337 to be wrapped in processing tools in QGIS. If used outside of mergin plugin, calculation of features lengths/areas will not be available.

PR also adds caching option for downloading diff files into .mergin folder, so the same files do not need to be downloaded again.

PR also modifies `project_versions` function to use paginated version of server endpoint. Non-paginated endpoints are deprecated on server and will be removed.

Possible enhancements in future:
 - run processing/reporting of files in parallel
 - create progress bar