### PR TITLE
check user permissions using "permissions" field

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -849,17 +849,16 @@ class MerginClient:
         conflicts = mp.resolve_unfinished_pull(self.username())
         return conflicts
 
-    def have_writing_permissions(self, directory):
+    def has_writing_permissions(self, project_path):
         """
         Test whether user has writing permissions on the given project.
         We rely on the "permissions" field here, as it provides more accurate
         information and take into account namespace permissions too.
 
-        :param directory: project's directory
+        :param project_path: project's path on server in the form or namespace/project
         :type directory: str
         :returns: whether user has writing (upload) permission on the project
         :rtype: bool
         """
-        mp = MerginProject(directory)
-        info = self.project_info(mp.metadata["name"])
+        info = self.project_info(project_path)
         return info["permissions"]["upload"]

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -848,3 +848,18 @@ class MerginClient:
         mp = MerginProject(directory)
         conflicts = mp.resolve_unfinished_pull(self.username())
         return conflicts
+
+    def have_writing_permissions(self, directory):
+        """
+        Test whether user has writing permissions on the given project.
+        We rely on the "permissions" field here, as it provides more accurate
+        information and take into account namespace permissions too.
+
+        :param directory: project's directory
+        :type directory: str
+        :returns: whether user has writing (upload) permission on the project
+        :rtype: bool
+        """
+        mp = MerginProject(directory)
+        info = self.project_info(mp.metadata["name"])
+        return info["permissions"]["upload"]

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -103,8 +103,8 @@ def push_project_async(mc, directory):
     username = mc.username()
     # permissions field contains information about update, delete and upload privileges of the user
     # on a specific project. This is more accurate information then "writernames" field, as it takes
-    # into account namespace privileges. So we have to check both "writersnames" and "permissions"
-    if (username not in server_info["access"]["writersnames"]) and not all(server_info["permissions"].values()):
+    # into account namespace privileges. So we have to check only "permissions", namely "upload" one
+    if not server_info["permissions"]["upload"]:
         mp.log.error(f"--- push {project_path} - username {username} does not have write access")
         raise ClientError(f"You do not seem to have write access to the project (username '{username}')")
 

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -104,7 +104,7 @@ def push_project_async(mc, directory):
     # permissions field contains information about update, delete and upload privileges of the user
     # on a specific project. This is more accurate information then "writernames" field, as it takes
     # into account namespace privileges. So we have to check only "permissions", namely "upload" one
-    if not mc.have_writing_permissions(directory):
+    if not mc.has_writing_permissions(project_path):
         mp.log.error(f"--- push {project_path} - username {username} does not have write access")
         raise ClientError(f"You do not seem to have write access to the project (username '{username}')")
 

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -101,7 +101,10 @@ def push_project_async(mc, directory):
     mp.log.info(f"got project info: local version {local_version} / server version {server_version}")
 
     username = mc.username()
-    if username not in server_info["access"]["writersnames"]:
+    # permissions field contains information about update, delete and upload privileges of the user
+    # on a specific project. This is more accurate information then "writernames" field, as it takes
+    # into account namespace privileges. So we have to check both "writersnames" and "permissions"
+    if (username not in server_info["access"]["writersnames"]) and not all(server_info["permissions"].values()):
         mp.log.error(f"--- push {project_path} - username {username} does not have write access")
         raise ClientError(f"You do not seem to have write access to the project (username '{username}')")
 

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -104,7 +104,7 @@ def push_project_async(mc, directory):
     # permissions field contains information about update, delete and upload privileges of the user
     # on a specific project. This is more accurate information then "writernames" field, as it takes
     # into account namespace privileges. So we have to check only "permissions", namely "upload" one
-    if not server_info["permissions"]["upload"]:
+    if not mc.have_writing_permissions(directory):
         mp.log.error(f"--- push {project_path} - username {username} does not have write access")
         raise ClientError(f"You do not seem to have write access to the project (username '{username}')")
 


### PR DESCRIPTION
As described in lutraconsulting/qgis-mergin-plugin#351 when user who is not an owner of the organization tries to sync project of the organization they get error. It happens because client relies on the `access` field of the project information to determine whether user has write permissions on a given project. However `access` field is taken from the explicit project permissions, while invited to the organization users get access via this organization.

In order to overcome this issue we need to check write access using `permissions` field, as this field is evaluated with respect to namespace.

Refs lutraconsulting/qgis-mergin-plugin#351

Refs CU-28km50n