### PR TITLE
if "to" version is not set assume latest project version when creating report

### DIFF
--- a/mergin/report.py
+++ b/mergin/report.py
@@ -207,7 +207,7 @@ def create_report(mc, directory, since, to, out_file):
         mc (MerginClient): MerginClient instance.
         directory (str): local project directory (must already exist).
         since (str): starting project version tag, for example 'v3'.
-        to (str): ending project version tag, for example 'v6'.
+        to (str): ending project version tag, for example 'v6'. If empty string is passed the latest version will be used.
         out_file (str): output file to save csv in
 
     Returns:
@@ -215,14 +215,15 @@ def create_report(mc, directory, since, to, out_file):
     """
     mp = MerginProject(directory)
     project = mp.metadata["name"]
-    mp.log.info(f"--- Creating changesets report for {project} from {since} to {to} versions ----")
-    versions_map = {v["name"]: v for v in mc.project_versions(project, since, to)}
+    mp.log.info(f"--- Creating changesets report for {project} from {since} to {to if to else 'latest'} versions ----")
+    versions = mc.project_versions(project, since, to if to else None)
+    versions_map = {v["name"]: v for v in versions}
     headers = ["file", "table", "author", "date", "time", "version", "operation", "length", "area", "count"]
     records = []
     warnings = []
     info = mc.project_info(project, since=since)
     num_since = int_version(since)
-    num_to = int_version(to)
+    num_to = int_version(to) if to else int_version(versions[-1]["name"])
     # filter only .gpkg files
     files = [f for f in info["files"] if mp.is_versioned_file(f["path"])]
     for f in files:

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1671,6 +1671,10 @@ def test_report(mc):
         # files not edited are not in reports
         assert "inserted_1_A.gpkg" not in content
 
+    # create report between versions 2 and latest version (which is version 5)
+    warnings = create_report(mc, directory, since, "", report_file)
+    assert warnings
+
     # do report for v1 with added files and v5 with overwritten file
     warnings = create_report(mc, directory, "v1", "v5", report_file)
     assert warnings


### PR DESCRIPTION
As described in lutraconsulting/qgis-mergin-plugin#365 when end project version is not set we will assume the latest project version when creating a report.