### PR TITLE
Fix issues with files and changesets downloading

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -618,6 +618,8 @@ def download_file_async(mc, project_dir, file_path, output_file, version):
     download_list = []
     update_tasks = []
     total_size = 0
+    if version is None:
+        version = latest_proj_info["version"]
     for file in project_info['files']:
         if file["path"] == file_path:
             file['version'] = version

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -618,6 +618,8 @@ def download_file_async(mc, project_dir, file_path, output_file, version):
     download_list = []
     update_tasks = []
     total_size = 0
+    # None can not be used to indicate latest version of the file, so
+    # it is necessary to pass actual version.
     if version is None:
         version = latest_proj_info["version"]
     for file in project_info['files']:

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1644,7 +1644,7 @@ def test_project_versions_list(mc):
     assert versions[-1]["name"] == "v4"
 
 def test_report(mc):
-    test_project = 'test_download_diffs'
+    test_project = 'test_report'
     project = API_USER + '/' + test_project
     project_dir = os.path.join(TMP_DIR, test_project)
     f_updated = "base.gpkg"

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1762,3 +1762,50 @@ def test_report_failure(mc):
 
     warnings = create_report(mc, project_dir, "v1", "v5", report_file)
     assert warnings
+
+
+def test_changesets_download(mc):
+    """Check that downloading diffs works correctly, including case when
+    changesets are cached.
+    """
+    test_project = 'test_changesets_download'
+    project = API_USER + '/' + test_project
+    project_dir = os.path.join(TMP_DIR, test_project)  # primary project dir
+    test_gpkg = 'test.gpkg'
+    file_path = os.path.join(project_dir, 'test.gpkg')
+    download_dir = os.path.join(TMP_DIR, "changesets")
+
+    cleanup(mc, project, [project_dir])
+
+    os.makedirs(project_dir, exist_ok=True)
+    shutil.copy(os.path.join(TEST_DATA_DIR, 'base.gpkg'), file_path)
+    mc.create_project_and_push(test_project, project_dir)
+
+    shutil.copy(os.path.join(TEST_DATA_DIR, 'inserted_1_A.gpkg'), file_path)
+    mc.push_project(project_dir)
+
+    shutil.copy(os.path.join(TEST_DATA_DIR, 'inserted_1_A_mod.gpkg'), file_path)
+    mc.push_project(project_dir)
+
+    mp = MerginProject(project_dir)
+
+    os.makedirs(download_dir, exist_ok=True)
+    diff_file = os.path.join(download_dir, "base-v1-2.diff")
+    mc.get_file_diff(project_dir, test_gpkg, diff_file, "v1", "v2")
+    assert os.path.exists(diff_file)
+    assert mp.geodiff.has_changes(diff_file)
+    assert mp.geodiff.changes_count(diff_file) == 1
+
+    diff_file = os.path.join(download_dir, "base-v2-3.diff")
+    mc.get_file_diff(project_dir, test_gpkg, diff_file, "v2", "v3")
+    assert os.path.exists(diff_file)
+    assert mp.geodiff.has_changes(diff_file)
+    assert mp.geodiff.changes_count(diff_file) == 2
+
+    # even if changesets were cached and were not downloaded destination
+    # file should be created and contain a valid changeset
+    diff_file = os.path.join(download_dir, "base-all.diff")
+    mc.get_file_diff(project_dir, test_gpkg, diff_file, "v1", "v3")
+    assert os.path.exists(diff_file)
+    assert mp.geodiff.has_changes(diff_file)
+    assert mp.geodiff.changes_count(diff_file) == 3


### PR DESCRIPTION
Fixes a couple of unreported issues related to downloading of files/changesets:

- passing `None` to `download_file()` method to indicate that the latest version of the file is requested does not work correctly. We have to pass actual version, otherwise server will return an error
- downloading of concatenated diff with `get_file_diff()` method does not work if some changesets were already cached. They are excluded from the download and never taken into account. As a result `get_file_diff()` fails to create an output diff.