### PR TITLE
add special handling for the names of the conflicted files for QGIS project files

### DIFF
--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1353,7 +1353,9 @@ def test_conflict_file_names():
             ('/home/test/geo.gpkg', '', 10, '/home/test/geo (conflicted copy,  v10).gpkg'),
             ('/home/test/geo.gpkg', 'jack', -1, '/home/test/geo (conflicted copy, jack v-1).gpkg'),
             ('/home/test/geo.tar.gz', 'jack', 100, '/home/test/geo (conflicted copy, jack v100).tar.gz'),
-            ('', 'jack', 1, '' )
+            ('', 'jack', 1, '' ),
+            ('/home/test/survey.qgs', 'jack', 10, '/home/test/survey (conflicted copy, jack v10).qgs~'),
+            ('/home/test/survey.QGZ', 'jack', 10, '/home/test/survey (conflicted copy, jack v10).QGZ~'),
            ]
 
     for i in data:

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -201,6 +201,8 @@ def conflicted_copy_file_name(path, user, version):
     head, tail = os.path.split(os.path.normpath(path))
     ext = ''.join(Path(tail).suffixes)
     file_name = tail.replace(ext, '')
+    if ext.lower() in (".qgz", ".qgs"):
+        ext += '~'
     return os.path.join(head, file_name) + f" (conflicted copy, {user} v{version}){ext}"
 
 


### PR DESCRIPTION
As discussed in https://github.com/lutraconsulting/qgis-mergin-plugin/issues/382 add `~` at the end of the conflicted copy if this is a QGIS project file.