### PR TITLE
Mark security issues as safe for security checks

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -330,10 +330,10 @@ class MerginProject:
 
         :Example:
 
-        >>> origin = [{'checksum': '08b0e8caddafe74bf5c11a45f65cedf974210fed', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]  # pragma: allowlist secret
-        >>> current = [{'checksum': 'c9a4fd2afd513a97aba19d450396a4c9df8b2ba4', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}]  # pragma: allowlist secret
+        >>> origin = [{'checksum': '1111111111111111111111111111111111111111', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]
+        >>> current = [{'checksum': '2222222222222222222222222222222222222222', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}]
         >>> self.compare_file_sets(origin, current)
-        {"added": [{'checksum': 'c9a4fd2afd513a97aba19d450396a4c9df8b2ba4', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}], "removed": [[{'checksum': '08b0e8caddafe74bf5c11a45f65cedf974210fed', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]], "renamed": [], "updated": []}
+        {"added": [{'checksum': '2222222222222222222222222222222222222222', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}], "removed": [[{'checksum': '1111111111111111111111111111111111111111', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]], "renamed": [], "updated": []}
 
         :param origin: origin set of files metadata
         :type origin: list[dict]

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -330,8 +330,8 @@ class MerginProject:
 
         :Example:
 
-        >>> origin = [{'checksum': '08b0e8caddafe74bf5c11a45f65cedf974210fed', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]
-        >>> current = [{'checksum': 'c9a4fd2afd513a97aba19d450396a4c9df8b2ba4', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}]
+        >>> origin = [{'checksum': '08b0e8caddafe74bf5c11a45f65cedf974210fed', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]  # pragma: allowlist secret
+        >>> current = [{'checksum': 'c9a4fd2afd513a97aba19d450396a4c9df8b2ba4', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}]  # pragma: allowlist secret
         >>> self.compare_file_sets(origin, current)
         {"added": [{'checksum': 'c9a4fd2afd513a97aba19d450396a4c9df8b2ba4', 'path': 'test.qgs', 'size': 31980, 'mtime': '2019-08-26T11:09:30.051221+02:00'}], "removed": [[{'checksum': '08b0e8caddafe74bf5c11a45f65cedf974210fed', 'path': 'base.gpkg', 'size': 2793, 'mtime': '2019-08-26T11:08:34.051221+02:00'}]], "renamed": [], "updated": []}
 

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1389,7 +1389,9 @@ def _get_table_row_count(db_file, table):
     try:
         con_verify = sqlite3.connect(db_file)
         cursor_verify = con_verify.cursor()
-        cursor_verify.execute("select count(*) from {};".format(table))  # nosec B608 - internal test helper, not using user input
+        cursor_verify.execute(
+            "select count(*) from {};".format(table)
+        )  # nosec B608 - internal test helper, not using user input
         return cursor_verify.fetchone()[0]
     finally:
         cursor_verify.close()

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1389,7 +1389,7 @@ def _get_table_row_count(db_file, table):
     try:
         con_verify = sqlite3.connect(db_file)
         cursor_verify = con_verify.cursor()
-        cursor_verify.execute("select count(*) from {};".format(table))  # nosec B608
+        cursor_verify.execute("select count(*) from {};".format(table))  # nosec B608 - internal test helper, not using user input
         return cursor_verify.fetchone()[0]
     finally:
         cursor_verify.close()
@@ -3085,7 +3085,7 @@ def test_uploaded_chunks_cache(mc):
 
     with open(file, "rb") as file_handle:
         data = file_handle.read()
-        checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
+        checksum = hashlib.sha1()  # nosec B324 - usedforsecurity=False flag is compatible with python 3.9+
         checksum.update(data)
         checksum_str = checksum.hexdigest()
         resp = mc.post(f"/v2/projects/{mp.project_id()}/chunks", data, {"Content-Type": "application/octet-stream"})

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1389,9 +1389,7 @@ def _get_table_row_count(db_file, table):
     try:
         con_verify = sqlite3.connect(db_file)
         cursor_verify = con_verify.cursor()
-        cursor_verify.execute(
-            "select count(*) from {};".format(table)
-        )  # nosec B608 - internal test helper, not using user input
+        cursor_verify.execute("select count(*) from {};".format(table))
         return cursor_verify.fetchone()[0]
     finally:
         cursor_verify.close()
@@ -3087,7 +3085,7 @@ def test_uploaded_chunks_cache(mc):
 
     with open(file, "rb") as file_handle:
         data = file_handle.read()
-        checksum = hashlib.sha1()  # nosec B324 - usedforsecurity=False flag is compatible with python 3.9+
+        checksum = hashlib.sha1()
         checksum.update(data)
         checksum_str = checksum.hexdigest()
         resp = mc.post(f"/v2/projects/{mp.project_id()}/chunks", data, {"Content-Type": "application/octet-stream"})

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -10,10 +10,8 @@ from datetime import datetime, timedelta, date, timezone
 import pytest
 import pytz
 import sqlite3
-import glob
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
-from unittest.mock import patch, Mock
 
 from .. import InvalidProject
 from ..client import (
@@ -1382,16 +1380,6 @@ def _create_spatial_table(db_file):
     cursor.execute("COMMIT;")
 
 
-def _delete_spatial_table(db_file):
-    """Drops spatial table called 'test' in sqlite database. Useful to simulate change of database schema."""
-    con = sqlite3.connect(db_file)
-    cursor = con.cursor()
-    cursor.execute("DROP TABLE poi;")
-    cursor.execute("DELETE FROM gpkg_geometry_columns WHERE table_name='poi';")
-    cursor.execute("DELETE FROM gpkg_contents WHERE table_name='poi';")
-    cursor.execute("COMMIT;")
-
-
 def _check_test_table(db_file):
     """Checks whether the 'test' table exists and has one row - otherwise fails with an exception."""
     assert _get_table_row_count(db_file, "test") == 1
@@ -1401,7 +1389,7 @@ def _get_table_row_count(db_file, table):
     try:
         con_verify = sqlite3.connect(db_file)
         cursor_verify = con_verify.cursor()
-        cursor_verify.execute("select count(*) from {};".format(table))
+        cursor_verify.execute("select count(*) from {};".format(table))  # nosec B608
         return cursor_verify.fetchone()[0]
     finally:
         cursor_verify.close()
@@ -3097,7 +3085,7 @@ def test_uploaded_chunks_cache(mc):
 
     with open(file, "rb") as file_handle:
         data = file_handle.read()
-        checksum = hashlib.sha1()
+        checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
         checksum.update(data)
         checksum_str = checksum.hexdigest()
         resp = mc.post(f"/v2/projects/{mp.project_id()}/chunks", data, {"Content-Type": "application/octet-stream"})

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import tempfile
 from enum import Enum
 from typing import Optional, Type, Union, ByteString
-from .common import ClientError, WorkspaceRole
+from .common import ClientError
 
 
 def generate_checksum(file, chunk_size=4096):
@@ -20,7 +20,7 @@ def generate_checksum(file, chunk_size=4096):
     :param chunk_size: size of chunk
     :return: sha1 checksum
     """
-    checksum = hashlib.sha1()
+    checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
     with open(file, "rb") as f:
         while True:
             chunk = f.read(chunk_size)
@@ -306,7 +306,7 @@ def get_data_checksum(data: ByteString) -> str:
     :param data: data to calculate checksum
     :return: sha1 checksum
     """
-    checksum = hashlib.sha1()
+    checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
     checksum.update(data)
     return checksum.hexdigest()
 

--- a/mergin/utils.py
+++ b/mergin/utils.py
@@ -20,7 +20,7 @@ def generate_checksum(file, chunk_size=4096):
     :param chunk_size: size of chunk
     :return: sha1 checksum
     """
-    checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
+    checksum = hashlib.sha1()  # nosec B324 - usedforsecurity=False flag is compatible with python 3.9+
     with open(file, "rb") as f:
         while True:
             chunk = f.read(chunk_size)
@@ -306,7 +306,7 @@ def get_data_checksum(data: ByteString) -> str:
     :param data: data to calculate checksum
     :return: sha1 checksum
     """
-    checksum = hashlib.sha1()  # nosec B324  # usedforsecurity=False flag is compatible with python 3.9+
+    checksum = hashlib.sha1()  # nosec B324 - usedforsecurity=False flag is compatible with python 3.9+
     checksum.update(data)
     return checksum.hexdigest()
 


### PR DESCRIPTION
Py-client part to resolve https://github.com/MerginMaps/qgis-plugin/issues/872

Flags used to tell security checks to skip the lines as they are safe.

More detail https://github.com/MerginMaps/qgis-plugin/pull/875