### PR TITLE
Adapt copy conflict changes

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -543,11 +543,10 @@ def pull_project_async(mc, directory) -> Optional[PullJob]:
         # find corresponding local delta item
         local_item = next((i for i in local_delta if i.path == change.path), None)
         local_item_change = local_item.type if local_item else None
+        local_item_checksum = local_item.checksum if local_item else None
 
         # compare server and local changes to decide what to do in pull
-        pull_action_type = mp.get_pull_action(
-            change.type, local_item_change, change.checksum, local_item.checksum if local_item else None
-        )
+        pull_action_type = mp.get_pull_action(change.type, local_item_change, change.checksum, local_item_checksum)
         if not pull_action_type:
             continue  # no action needed
 

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -545,7 +545,9 @@ def pull_project_async(mc, directory) -> Optional[PullJob]:
         local_item_change = local_item.type if local_item else None
 
         # compare server and local changes to decide what to do in pull
-        pull_action_type = mp.get_pull_action(change.type, local_item_change)
+        pull_action_type = mp.get_pull_action(
+            change.type, local_item_change, change.checksum, local_item.checksum if local_item else None
+        )
         if not pull_action_type:
             continue  # no action needed
 

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -504,7 +504,11 @@ class MerginProject:
         return ProjectDelta(to_version=server_version, changes=result)
 
     def get_pull_action(
-        self, server_change: DeltaChangeType, local_change: Optional[DeltaChangeType] = None
+        self,
+        server_change: DeltaChangeType,
+        local_change: Optional[DeltaChangeType] = None,
+        server_checksum=None,
+        local_checksum=None,
     ) -> Optional[PullActionType]:
         """
         Determine pull actions for files by comparing server_change and local_change.
@@ -520,11 +524,17 @@ class MerginProject:
             self.log.critical(f"Invalid combination of changes: server {server_change}, local {local_change}")
             raise ClientError(f"Invalid combination of changes: server {server_change}, local {local_change}")
 
+        checksum_conflict = server_checksum != local_checksum if server_checksum and local_checksum else False
+
         pull_action_map = {
             (DeltaChangeType.CREATE, None): PullActionType.COPY,
-            (DeltaChangeType.CREATE, DeltaChangeType.CREATE): PullActionType.COPY_CONFLICT,
+            (DeltaChangeType.CREATE, DeltaChangeType.CREATE): (
+                PullActionType.COPY_CONFLICT if checksum_conflict else None
+            ),
             (DeltaChangeType.UPDATE, None): PullActionType.COPY,
-            (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE): PullActionType.COPY_CONFLICT,
+            (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE): (
+                PullActionType.COPY_CONFLICT if checksum_conflict else None
+            ),
             (DeltaChangeType.UPDATE, DeltaChangeType.DELETE): PullActionType.COPY,
             (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE_DIFF): PullActionType.COPY_CONFLICT,
             (DeltaChangeType.UPDATE, DeltaChangeType.CREATE): PullActionType.COPY_CONFLICT,

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -507,8 +507,8 @@ class MerginProject:
         self,
         server_change: DeltaChangeType,
         local_change: Optional[DeltaChangeType] = None,
-        server_checksum=None,
-        local_checksum=None,
+        server_checksum: Optional[str] = None,
+        local_checksum: Optional[str] = None,
     ) -> Optional[PullActionType]:
         """
         Determine pull actions for files by comparing server_change and local_change.

--- a/mergin/test/test_mergin_project.py
+++ b/mergin/test/test_mergin_project.py
@@ -82,27 +82,29 @@ def test_get_pull_action_valid():
     with tempfile.TemporaryDirectory() as tmp_dir:
         mp = MerginProject(tmp_dir)
 
-    # Test cases: (server_change, local_change, expected_action)
+    # Test cases: (server_change, local_change, server_checksum, local_checksum, expected_action)
     test_cases = [
-        (DeltaChangeType.CREATE, None, PullActionType.COPY),
-        (DeltaChangeType.CREATE, DeltaChangeType.CREATE, PullActionType.COPY_CONFLICT),
-        (DeltaChangeType.UPDATE, None, PullActionType.COPY),
-        (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE, PullActionType.COPY_CONFLICT),
-        (DeltaChangeType.UPDATE, DeltaChangeType.DELETE, PullActionType.COPY),
-        (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE_DIFF, PullActionType.COPY_CONFLICT),
-        (DeltaChangeType.UPDATE, DeltaChangeType.CREATE, PullActionType.COPY_CONFLICT),
-        (DeltaChangeType.UPDATE_DIFF, None, PullActionType.APPLY_DIFF_NO_REBASE),
-        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.UPDATE, PullActionType.COPY_CONFLICT),
-        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.DELETE, PullActionType.COPY),
-        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.UPDATE_DIFF, PullActionType.APPLY_DIFF_REBASE),
-        (DeltaChangeType.DELETE, None, PullActionType.DELETE),
-        (DeltaChangeType.DELETE, DeltaChangeType.UPDATE, None),
-        (DeltaChangeType.DELETE, DeltaChangeType.DELETE, None),
-        (DeltaChangeType.DELETE, DeltaChangeType.UPDATE_DIFF, None),
+        (DeltaChangeType.CREATE, None, None, None, PullActionType.COPY),
+        (DeltaChangeType.CREATE, DeltaChangeType.CREATE, "c1", "c2", PullActionType.COPY_CONFLICT),
+        (DeltaChangeType.CREATE, DeltaChangeType.CREATE, "c1", "c1", None),
+        (DeltaChangeType.UPDATE, None, None, None, PullActionType.COPY),
+        (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE, "c1", "c2", PullActionType.COPY_CONFLICT),
+        (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE, "c1", "c1", None),
+        (DeltaChangeType.UPDATE, DeltaChangeType.DELETE, "c1", "c2", PullActionType.COPY),
+        (DeltaChangeType.UPDATE, DeltaChangeType.UPDATE_DIFF, "c1", "c2", PullActionType.COPY_CONFLICT),
+        (DeltaChangeType.UPDATE, DeltaChangeType.CREATE, "c1", "c2", PullActionType.COPY_CONFLICT),
+        (DeltaChangeType.UPDATE_DIFF, None, "c1", "c2", PullActionType.APPLY_DIFF_NO_REBASE),
+        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.UPDATE, "c1", "c2", PullActionType.COPY_CONFLICT),
+        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.DELETE, "c1", "c2", PullActionType.COPY),
+        (DeltaChangeType.UPDATE_DIFF, DeltaChangeType.UPDATE_DIFF, "c1", "c2", PullActionType.APPLY_DIFF_REBASE),
+        (DeltaChangeType.DELETE, None, "c1", "c2", PullActionType.DELETE),
+        (DeltaChangeType.DELETE, DeltaChangeType.UPDATE, None, None, None),
+        (DeltaChangeType.DELETE, DeltaChangeType.DELETE, None, None, None),
+        (DeltaChangeType.DELETE, DeltaChangeType.UPDATE_DIFF, None, None, None),
     ]
 
-    for server_change, local_change, expected_action in test_cases:
-        action = mp.get_pull_action(server_change, local_change)
+    for server_change, local_change, server_checksum, local_checksum, expected_action in test_cases:
+        action = mp.get_pull_action(server_change, local_change, server_checksum, local_checksum)
         assert (
             action == expected_action
         ), f"Failed for {server_change}, {local_change}. Expected {expected_action}, got {action}"
@@ -123,7 +125,7 @@ def test_get_pull_action_fatal():
 
     for server_change, local_change in fatal_cases:
         with pytest.raises(ClientError, match="Invalid combination of changes"):
-            mp.get_pull_action(server_change, local_change)
+            mp.get_pull_action(server_change, local_change, None, None)
 
 
 def test_get_pull_delta():


### PR DESCRIPTION
When file is updated and created on the server and user is having the same file (with same checksum) - do not create conflicting copy. This change will be ignored during pull:

- no download of a file from server
- no changes are adapted to users local directory
- no copy conflict if checksum of a file is the same as in users directory

**Simulation NO conflicts -> CREATE - CREATE** ✅ 

- create project
- download project to 2 clients
- create project version from client 1 - local.txt with some content ("Hello!") -> PUSH
- create the same file in client 2 local directory
- sync changes into client 2
- file will be there and no conflicitng copy for local.txt file created

**Simulation CONFLICTS -> CREATE - CREATE** ✅ 

- create project
- download project to 2 clients
- create project version from client 1 - local.txt with some content ("Hello!") -> PUSH
- create the same file in client 2 local directory but with different content ("Hello world!)
- sync changes into client 2
- file will be there from server with content Hello! and conflicitng copy for local.txt file created with `Hello world!`

**Simulation NO conflicts -> UPDATE - UPDATE** ✅ 

- create project
- download project to 2 clients
- create project version from client 1 - local.txt with some content ("Hello!") -> PUSH
- sync changes to client 2 - local.txt file is created
- update file local.txt in client 1 directory ("Hello world!") -> PUSH
- update file local.txt from client 2 directory ("Hello world!")
- sync changes into client 2
- file will be there with content `Hello world!` and no conflicitng copy for local.txt file created

**Simulation CONFLICTS -> UPDATE - UPDATE** ✅   
Note: no changes in file preview on web - new bug [#3308](https://github.com/MerginMaps/server-private/issues/3308)
<img src="https://github.com/user-attachments/assets/da9d3dbe-2bda-4f7c-bb01-d1ba677423d1" width="250"/>
<img src="https://github.com/user-attachments/assets/e642804d-68b7-4674-88f2-4d76c3350c63" width="250"/>


- create project
- download project to 2 clients
- create project version from client 1 - local.txt with some content ("Hello!") -> PUSH
- sync changes to client 2 - local.txt file is created
- update file local.txt in client 1 directory ("Hello world!") -> PUSH
- update file local.txt from client 2 directory ("Hello QGIS!")
- sync changes into client 2
- file will be there with content `Hello world!` and conflicitng copy for local.txt file created with content `Hello QGIS!`
