### PR TITLE
Add function to explicitly allow including only specific tables

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -1079,6 +1079,9 @@ class MerginProject:
 
         If empty list is passed, list will be reset.
 
+        This method is mutually exclusive with set_tables_to_include() and error
+        GeoDiffLibError will be raised if both are set.
+
         :param tables: list of table names to ignore
         :type tables: list[str]
         """
@@ -1092,6 +1095,9 @@ class MerginProject:
         between different drivers.
 
         If empty list is passed, list will be reset.
+
+        This method is mutually exclusive with set_tables_to_skip() and error
+        GeoDiffLibError will be raised if both are set.
 
         :param tables: list of table names to include
         :type tables: list[str]

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -1084,6 +1084,20 @@ class MerginProject:
         """
         self.geodiff.set_tables_to_skip(tables)
 
+    def set_tables_to_include(self, tables: List[str]):
+        """
+        Set list of tables to include in geodiff operations. Once defined, only these
+        tables will be included in the following operations: create changeset, apply
+        changeset, rebase, get database schema, dump database contents, copy database
+        between different drivers.
+
+        If empty list is passed, list will be reset.
+
+        :param tables: list of table names to include
+        :type tables: list[str]
+        """
+        self.geodiff.set_tables_to_include(tables)
+
     def get_geodiff_changes_count(self, diff_rel_path: str):
         """
         Best-effort: return number of changes in the .gpkg diff (int) or None.

--- a/mergin/test/test_mergin_project.py
+++ b/mergin/test/test_mergin_project.py
@@ -444,7 +444,6 @@ def test_set_tables_to_skip():
 
 def test_set_tables_to_include():
     """Only tables in set_tables_to_include appear in the changeset."""
-    # two_tables.gpkg -> two_tables_1_A.gpkg: only survey changes, simple is unchanged
     base = os.path.join(TEST_DATA_DIR, "two_tables.gpkg")
     modified = os.path.join(TEST_DATA_DIR, "two_tables_1_A.gpkg")
 

--- a/mergin/test/test_mergin_project.py
+++ b/mergin/test/test_mergin_project.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import pytest
 from mergin.merginproject import MerginProject
+from pygeodiff import GeoDiffLibError
 from mergin.common import DeltaChangeType, PullActionType, ClientError
 from mergin.models import ProjectDeltaChange, ProjectDeltaItemDiff
 from mergin.client_pull import PullAction
@@ -418,3 +419,56 @@ def test_apply_pull_actions_copy_conflict():
         assert not mp.geodiff.has_changes(os.path.join(tmp_dir, "live-server.diff"))
         assert not mp.geodiff.has_changes(os.path.join(tmp_dir, "live-base.diff"))
         assert mp.geodiff.has_changes(os.path.join(tmp_dir, "live-conflict.diff"))
+
+
+def test_set_tables_to_skip():
+    """Tables in set_tables_to_skip are excluded from changeset creation."""
+    base = os.path.join(TEST_DATA_DIR, "two_tables.gpkg")
+    modified = os.path.join(TEST_DATA_DIR, "two_tables_1_A.gpkg")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mp = MerginProject(tmp_dir)
+        diff = os.path.join(tmp_dir, "diff.diff")
+
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert mp.geodiff.has_changes(diff)
+
+        mp.set_tables_to_skip(["survey"])
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert not mp.geodiff.has_changes(diff)
+
+        mp.set_tables_to_skip([])
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert mp.geodiff.has_changes(diff)
+
+
+def test_set_tables_to_include():
+    """Only tables in set_tables_to_include appear in the changeset."""
+    # two_tables.gpkg -> two_tables_1_A.gpkg: only survey changes, simple is unchanged
+    base = os.path.join(TEST_DATA_DIR, "two_tables.gpkg")
+    modified = os.path.join(TEST_DATA_DIR, "two_tables_1_A.gpkg")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mp = MerginProject(tmp_dir)
+        diff = os.path.join(tmp_dir, "diff.diff")
+
+        mp.set_tables_to_include(["simple"])
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert not mp.geodiff.has_changes(diff)
+
+        mp.set_tables_to_include(["survey"])
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert mp.geodiff.has_changes(diff)
+
+        mp.set_tables_to_include([])
+        mp.geodiff.create_changeset(base, modified, diff)
+        assert mp.geodiff.has_changes(diff)
+
+
+def test_tables_to_skip_and_include_mutually_exclusive():
+    """Setting both skip and include lists should raise an error."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mp = MerginProject(tmp_dir)
+        mp.set_tables_to_skip(["table_a"])
+        with pytest.raises(GeoDiffLibError):
+            mp.set_tables_to_include(["table_b"])

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     platforms="any",
     install_requires=[
         "python-dateutil==2.8.2",
-        "pygeodiff==2.2.0",
+        "pygeodiff==2.3.0",
         "pytz==2022.1",
         "click==8.1.3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mergin-client",
-    version="0.13.1",
+    version="0.14.0",
     url="https://github.com/MerginMaps/python-api-client",
     license="MIT",
     author="Lutra Consulting Ltd.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mergin-client",
-    version="0.14.0",
+    version="0.13.1",
     url="https://github.com/MerginMaps/python-api-client",
     license="MIT",
     author="Lutra Consulting Ltd.",


### PR DESCRIPTION
This follows PR in **geodiff** (MerginMaps/geodiff#254) to specifically allow including only of specific tables. 